### PR TITLE
Add Tkinter GUI for desktop assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ python -m assistant GL-05 預製圖 308
 
 會列出 Top-N 結果，輸入編號即可開啟，並自動記錄學習偏置到 data/learn_bias.json。
 
+若想要圖形介面，可執行：
+```bash
+python -m assistant.gui
+```
+輸入關鍵詞後按「搜尋」，雙擊結果即可開啟對應項目，並同樣會記錄正/負向學習。
+
 
 ---
 

--- a/src/assistant/gui.py
+++ b/src/assistant/gui.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+import tkinter as tk
+from tkinter import ttk, messagebox
+from assistant.memory.memory_manager import load_memory
+from assistant.search.smart_search import SmartSearch
+from assistant.actions.openers import run_action
+
+
+def run_gui():
+    items = load_memory()
+    if not items:
+        messagebox.showinfo("提示", "memory_data.json 是空的或找不到，先放幾個記憶點吧。")
+        return
+
+    engine = SmartSearch(items)
+
+    root = tk.Tk()
+    root.title("Smart Desktop Assistant")
+
+    frame = ttk.Frame(root, padding=10)
+    frame.pack(fill="both", expand=True)
+
+    query_var = tk.StringVar()
+    entry = ttk.Entry(frame, textvariable=query_var)
+    entry.pack(fill="x")
+    entry.focus()
+
+    result_list = tk.Listbox(frame, height=10)
+    result_list.pack(fill="both", expand=True, pady=5)
+
+    def search():
+        q = query_var.get().strip()
+        result_list.delete(0, tk.END)
+        if not q:
+            return
+        results = engine.search(q, top_k=10)
+        result_list.results = results
+        for score, it in results:
+            desc = it.get("description") or "(無描述)"
+            result_list.insert(tk.END, f"{score:.3f} {desc}")
+
+    def open_selected(event=None):
+        selection = result_list.curselection()
+        if not selection:
+            return
+        idx = selection[0]
+        score, chosen = result_list.results[idx]
+        ok = run_action(chosen.get("action") or "open_folder", chosen.get("path") or "")
+        if ok:
+            engine.learn_positive(query_var.get(), chosen)
+            messagebox.showinfo("已開啟", "✅ 已開啟，並記錄為正向回饋。")
+        else:
+            engine.learn_negative(query_var.get(), chosen)
+            messagebox.showwarning("開啟失敗", "⚠️ 開啟失敗（或路徑無效），已記錄為負向回饋。")
+
+    btn = ttk.Button(frame, text="搜尋", command=search)
+    btn.pack(pady=5)
+
+    result_list.bind("<Double-Button-1>", open_selected)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    run_gui()


### PR DESCRIPTION
## Summary
- add a simple Tkinter GUI for searching memory items and opening results
- document GUI usage in README

## Testing
- `PYTHONPATH=src python -m assistant --help`
- `PYTHONPATH=src python -m assistant.gui` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68c76189c844832b8f8d8a306bbad838